### PR TITLE
babel cacheDirectory 사용

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,6 +18,9 @@ module.exports = {
         exclude: /node_module/,
         use: {
           loader: 'babel-loader',
+          options: {
+            cacheDirectory: true
+          },
         },
       },
     ],


### PR DESCRIPTION
[babel-loader](https://webpack.js.org/loaders/babel-loader/)

cacheDirectory: Default false. When set, the given directory will be used to cache the results of the loader. Future webpack builds will attempt to read from the cache to avoid needing to run the potentially expensive Babel recompilation process on each run. If the value is set to true in options ({cacheDirectory: true}), the loader will use the default cache directory in node_modules/.cache/babel-loader or fallback to the default OS temporary file directory if no node_modules folder could be found in any root directory.

해당 옵션을 키면 빌드 시 속도가 비약적으로 상승합니다