### PR TITLE
use npm ci

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Package
         uses: bahmutov/npm-install@v1
         with:
-          install-command: npm i --force
+          install-command: npm ci --force
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
동일한 패키지를 다운받게 했습니다.
또한  actions/create-release은 개발이 중지되었으니

https://github.com/softprops/action-gh-release 같은 
다른 걸 사용하시는걸 추천드립니다.