### PR TITLE
run-at을 document-start로 변경

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -16,19 +16,23 @@ const appendAppContainer = () => {
   ReactDOM.render(<App />, appContainer);
 };
 
-if(!document.body) { //@run-at document-start은 document.body가 없을 때 실행될 수 있음
+if (!document.body) {
+  // @run-at document-start은 document.body가 없을 때 실행될 수 있음
   // MutationObserver로 body가 추가되는 것을 감지하여 appendAppContainer를 실행
-  const mutationObserver = new MutationObserver((mutations) => {
+  const mutationObserver = new MutationObserver((mutations, obs) => {
     mutations.forEach((mutation) => {
       mutation.addedNodes.forEach((node) => {
-        if(node.nodeName.toLocaleUpperCase() === 'BODY') {
+        if (node.nodeName.toLocaleUpperCase() === 'BODY') {
           appendAppContainer();
-          mutationObserver.disconnect();
+          obs.disconnect();
         }
-      })
+      });
     });
-  }); 
-}
-else {
+  });
+  mutationObserver.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+} else {
   appendAppContainer();
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,7 +9,26 @@ import App from './App';
  */
 window.console = unsafeWindow.console;
 
-const appContainer = document.createElement('div');
-document.body.append(appContainer);
+const appendAppContainer = () => {
+  const appContainer = document.createElement('div');
+  document.body.append(appContainer);
 
-ReactDOM.render(<App />, appContainer);
+  ReactDOM.render(<App />, appContainer);
+};
+
+if(!document.body) { //@run-at document-start은 document.body가 없을 때 실행될 수 있음
+  // MutationObserver로 body가 추가되는 것을 감지하여 appendAppContainer를 실행
+  const mutationObserver = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if(node.nodeName.toLocaleUpperCase() === 'BODY') {
+          appendAppContainer();
+          mutationObserver.disconnect();
+        }
+      })
+    });
+  }); 
+}
+else {
+  appendAppContainer();
+}

--- a/src/meta.json
+++ b/src/meta.json
@@ -12,7 +12,7 @@
   "exclude": ["https://*.arca.live/api/*"],
   "connect": ["namu.la", "saucenao.com", "ascii2d.net"],
   "noframes": true,
-  "run-at": "document-body",
+  "run-at": "document-start",
   "grant": [
     "GM_info",
     "GM_openInTab",

--- a/src/proxy-meta.json
+++ b/src/proxy-meta.json
@@ -12,7 +12,7 @@
   "exclude": ["https://*.arca.live/api/*"],
   "connect": ["namu.la", "saucenao.com", "ascii2d.net"],
   "noframes": true,
-  "run-at": "document-body",
+  "run-at": "document-start",
   "grant": [
     "GM_info",
     "GM_openInTab",


### PR DESCRIPTION
Tampermonkey, AdGuard가 아닌 [Violentmonkey](https://violentmonkey.github.io/api/metadata-block/#run-at) 등 일부 환경에서는 @run-at document-body가 지원되지 않습니다.

따라서 @run-at을 document-start로 변경하고, @run-at document-body와 동일하게 작동시키기 위해 body가 존재하지 않을 시 MutationObserver를 사용해 body가 생겼을 시 실행도록 했습니다.

물론  Tampermonkey, AdGuard 이외의 환경의 실행은 보장되지 않다고 되어있지만, 바꾼다고 나쁘진 않다고 생각해서...